### PR TITLE
Make the default filter order an array

### DIFF
--- a/src/themes/theme_generator.jsx
+++ b/src/themes/theme_generator.jsx
@@ -83,7 +83,7 @@ const generate_theme = (vars, theme_vars) => {
     mapSwitchSmall: vars.hasOwnProperty("mapSwitchSmall")
       ? vars.mapSwitchSmall
       : true,
-    filterOrder: vars.hasOwnProperty("filterOrder") ? vars.filterOrder : {},
+    filterOrder: vars.hasOwnProperty("filterOrder") ? vars.filterOrder : [],
     usePresetTaxonomies: determineUsePresetTaxonomies(vars),
     presetTaxonomies: vars.hasOwnProperty("presetTaxonomies")
       ? vars.presetTaxonomies


### PR DESCRIPTION
I tried running the app locally and ran into an error. We expect the filter order to be an array of objects, and we call `.sort` on it, but we had set the default to be an object, which doesn't respond to `.sort`.

This updates the default filter order to be an empty array so the app runs even when no theme is set.