### PR TITLE
fix an issue where if there were duplicate categories an error occurs

### DIFF
--- a/src/components/Filter/RadioFilter.jsx
+++ b/src/components/Filter/RadioFilter.jsx
@@ -65,8 +65,8 @@ const RadioFilter = ({
     return (
       <Outer>
         <Content>
-          {options.map(o => (
-            <StyledField key={o.slug}>
+          {options.map((o, i) => (
+            <StyledField key={`${o.slug}_${i}`}>
               <Input
                 type="radio"
                 id={o.slug}


### PR DESCRIPTION
Tiny one but has come up a few times - in the very off chance there are two of the same top level categories react throws an error - just making the key a bit more robust here