### PR TITLE
Set url based on deploy context

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-16
+lts/gallium

--- a/plugins/netlify-add-netlify-build-vars/index.js
+++ b/plugins/netlify-add-netlify-build-vars/index.js
@@ -4,7 +4,7 @@ module.exports = {
   onPreBuild({ netlifyConfig }) {
     // Modify build command's environment variables
     netlifyConfig.build.environment.REACT_APP_SITE_URL =
-      process.env.context === "production"
+      process.env.CONTEXT === "production"
         ? process.env.URL
         : process.env.DEPLOY_PRIME_URL
   },


### PR DESCRIPTION
If deploying to netlify production then `REACT_APP_SITE_URL` is set to the correct url for the netlify site eg directory.domain.com other contexts it is set to staging--site.netlify.com 

if not deploying to netlify then `REACT_APP_SITE_URL` will need to be set to build the site correctly

