### PR TITLE
Handle rate limit errrors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,6 +89,7 @@ const App = ({ children, location, navigate }) => {
   const [mapVisible, setMapVisible] = useQuery("map", false, { boolean: true })
 
   const [results, setResults] = useState([])
+  const [status, setStatus] = useState([])
   const [loading, setLoading] = useState(true)
 
   const [page, setPage] = useState(1)
@@ -115,6 +116,7 @@ const App = ({ children, location, navigate }) => {
 
   const handleResults = useCallback(
     (services, search, includePrevServices = false) => {
+      setStatus(services.status)
       setResults(prevResults => {
         const newResults = includePrevServices
           ? [...prevResults, ...services.content]
@@ -446,6 +448,7 @@ const App = ({ children, location, navigate }) => {
           <MainContent
             loading={loading}
             results={results}
+            status={status}
             keywords={keywords}
             coverage={coverage}
             mapVisible={mapVisible}
@@ -468,6 +471,7 @@ const App = ({ children, location, navigate }) => {
 const MainContent = ({
   loading,
   results,
+  status,
   keywords,
   coverage,
   mapVisible,
@@ -503,6 +507,15 @@ const MainContent = ({
           <Skeleton />
         </ResultsList>
       </>
+    )
+
+  // if we get a 429 status code then we've made too many requests and we show a specific message
+  if (status && status.includes(429))
+    return (
+      <NoResults>
+        It looks like you've made too many requests in a short period. Please
+        wait a few minutes and try again.
+      </NoResults>
     )
 
   // not loading and no results

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -63,6 +63,8 @@ export const fetchServiceData = async (query, page) => {
       : [fetchServiceDataFromApi(query, taxonomies, per_page * 2, page)]
   )
 
+  const combinedStatus = results.map(r => r?.status).flat()
+
   let sortedResults = []
   let moreResults = 0
   let estTotalResults = 0
@@ -79,6 +81,7 @@ export const fetchServiceData = async (query, page) => {
   }
 
   return {
+    status: combinedStatus,
     content: sortedResults,
     moreResults,
     estTotalResults,
@@ -150,14 +153,23 @@ export const fetchServiceDataFromApi = async (
 
   try {
     const res = await fetch(url)
+
+    // Handle non-2xx HTTP responses
+    if (!res.ok) {
+      // const errorData = await res.json()
+      // console.log(errorData)
+      return { content: [], status: res.status }
+    }
+
     const results = await res.json()
     // add query number to each result so we can track which query it came from
     results.content = results.content.map(r => (r = { ...r, query_num }))
+    results.status = res.status
     return results
   } catch (err) {
     console.error("An error occurred fetching data from Outpost API")
-    // console.log(err)
-    return { content: [] }
+    console.log(err)
+    return { content: [], status: 400 }
   }
 }
 

--- a/src/lib/data-helpers.js
+++ b/src/lib/data-helpers.js
@@ -90,6 +90,7 @@ export const defineQueryTaxonomies = (collection, categories) => {
 }
 
 export const removeDuplicateServices = services => {
+  if (services || services.length === 0) return services
   return services.filter(
     (service, index, self) => index === self.findIndex(t => t.id === service.id)
   )


### PR DESCRIPTION
In most cases of an API failure we show a generic message however if the rate limit has been reached then this is a different use case so it gets its own error message

Also fixed an issue where it was trying to filter an empty array and causes an error on the page.


<img width="1090" alt="image" src="https://github.com/user-attachments/assets/c1ca7d45-154c-475f-aee1-58baab52413c" />
