### PR TITLE
Fix for duplicate services in filtered results

### DIFF
--- a/src/lib/data-helpers.js
+++ b/src/lib/data-helpers.js
@@ -90,7 +90,7 @@ export const defineQueryTaxonomies = (collection, categories) => {
 }
 
 export const removeDuplicateServices = services => {
-  if (services || services.length === 0) return services
+  if (!services || services.length === 0) return services
   return services.filter(
     (service, index, self) => index === self.findIndex(t => t.id === service.id)
   )


### PR DESCRIPTION
Resolves typo to only immediately return `services` argument if it's false-y or empty